### PR TITLE
#2 [DOCS] Update attendance, assignments, PR statuses, and fix slide diagrams

### DIFF
--- a/ATTENDANCE.md
+++ b/ATTENDANCE.md
@@ -2,27 +2,62 @@
 
 Location: 507 НТП | Time: 17:00
 
+## 🏆 Leaderboard
+
+| Rank | Student | 🟢 Merged | ✅ Approved | 🟡 Open | 🔴 Rejected | Score | Streak |
+|------|---------|-----------|------------|---------|-------------|-------|--------|
+| 🥇 | Aleksandar Cetkovic | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
+| 🥇 | Jovan Glintic | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
+| 3 | Aleksandar Antonic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Ana Zec | 0 | 0 | 0 | 1 | 0 | |
+| 3 | Ante Resetar | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Jana Petrovic | 0 | 0 | 0 | 1 | 0 | |
+| 3 | Luka Misojcic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Luka Vidakovic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Mihailo Dikanovic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Nikola Boskovic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Stefan Mitic | 0 | 0 | 0 | 0 | 0 | |
+| 3 | Vuk Antovic | 0 | 0 | 0 | 1 | 0 | |
+
+**Scoring:** 🟡 Open = 2 pts | ✅ Approved = 4 pts | 🟢 Merged = 5 pts | 🔴 Changes Requested = 0 pts
+**Streak:** Consecutive modules with a PR submitted 🔥
+**Bonus:** First to merge a module PR = +3 pts ⚡
+
 ## Week 1
 
-| Student | Tue 7.4. | Wed 8.4. | Thu 9.4. | ~~Fri 10.4.~~ |
-|---------|----------|----------|----------|---------------|
-| Aleksandar Cetkovic | ❌ | ✅ | | |
-| Jovan Glintic | ✅ | ✅ | | |
-| Jana Petrovic | ❌ | ✅ | | |
-| Vuk Antovic | ✅ | ✅ | | |
-| Ana Zec | ❌ | ❌ | | |
+| # | Student | Tue 7.4. | Wed 8.4. | Thu 9.4. | ~~Fri 10.4.~~ |
+|---|---------|----------|----------|----------|---------------|
+| 1 | Aleksandar Antonic | ✅ | ❌ | ✅ | |
+| 2 | Aleksandar Cetkovic | ❌ | ✅ | ✅ | |
+| 3 | Ana Zec | ✅ | ❌ | ✅ | |
+| 4 | Ante Resetar | ✅ | ❌ | ✅ | |
+| 5 | Jana Petrovic | ❌ | ✅ | ✅ | |
+| 6 | Jovan Glintic | ✅ | ✅ | ✅ | |
+| 7 | Luka Misojcic | ❌ | ❌ | ✅ | |
+| 8 | Luka Vidakovic | ❌ | ❌ | ❌ | |
+| 9 | Mihailo Dikanovic | ❌ | ❌ | ✅ | |
+| 10 | Nikola Boskovic | ❌ | ❌ | ✅ | |
+| 11 | Stefan Mitic | ❌ | ❌ | ✅ | |
+| 12 | Vuk Antovic | ✅ | ✅ | ✅ | |
 
 Friday 10.4. — no class (Good Friday)
 
 ## Week 2
 
-| Student | ~~Mon 14.4.~~ | Tue 15.4. | Thu 17.4. | Fri 18.4. |
-|---------|---------------|-----------|-----------|-----------|
-| Aleksandar Cetkovic | | | | |
-| Jovan Glintic | | | | |
-| Jana Petrovic | | | | |
-| Vuk Antovic | | | | |
-| Ana Zec | | | | |
+| # | Student | ~~Mon 14.4.~~ | Tue 15.4. | Thu 17.4. | Fri 18.4. |
+|---|---------|---------------|-----------|-----------|-----------|
+| 1 | Aleksandar Antonic | | | | |
+| 2 | Aleksandar Cetkovic | | | | |
+| 3 | Ana Zec | | | | |
+| 4 | Ante Resetar | | | | |
+| 5 | Jana Petrovic | | | | |
+| 6 | Jovan Glintic | | | | |
+| 7 | Luka Misojcic | | | | |
+| 8 | Luka Vidakovic | | | | |
+| 9 | Mihailo Dikanovic | | | | |
+| 10 | Nikola Boskovic | | | | |
+| 11 | Stefan Mitic | | | | |
+| 12 | Vuk Antovic | | | | |
 
 Monday 14.4. — no class
 
@@ -30,10 +65,36 @@ Monday 14.4. — no class
 
 Project work (schedule TBD)
 
-| Student | Session 1 | Session 2 | Session 3 |
-|---------|-----------|-----------|-----------|
-| Aleksandar Cetkovic | | | |
-| Jovan Glintic | | | |
-| Jana Petrovic | | | |
-| Vuk Antovic | | | |
-| Ana Zec | | | |
+| # | Student | Session 1 | Session 2 | Session 3 |
+|---|---------|-----------|-----------|-----------|
+| 1 | Aleksandar Antonic | | | |
+| 2 | Aleksandar Cetkovic | | | |
+| 3 | Ana Zec | | | |
+| 4 | Ante Resetar | | | |
+| 5 | Jana Petrovic | | | |
+| 6 | Jovan Glintic | | | |
+| 7 | Luka Misojcic | | | |
+| 8 | Luka Vidakovic | | | |
+| 9 | Mihailo Dikanovic | | | |
+| 10 | Nikola Boskovic | | | |
+| 11 | Stefan Mitic | | | |
+| 12 | Vuk Antovic | | | |
+
+## Student Directory
+
+| # | Student | Index | Email | M1 PR | M2 PR | M3 PR | M4 PR | M5 PR | Project PR |
+|---|---------|-------|-------|-------|-------|-------|-------|-------|------------|
+| 1 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | E2 69/2025 | <aleksandar.antonic00@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 2 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | E2 2/2025 | <aleksandarcetkovic@gmail.com> | [#4](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pull/4) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 3 | [Ana Zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | E2 71/2025 | <ana.zecus@gmail.com> | [#12](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/12) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 4 | Ante Resetar | E2 74/2025 | <ante.resetar@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | E2 105/2025 | <petrovic.jana12@gmail.com> | [#7](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pull/7) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 6 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | E2 51/2025 | <jovanglintic@gmail.com> | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 7 | Luka Misojcic | E2 39/2025 | <luka.misojcic.2019@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 8 | Luka Vidakovic | E2 40/2025 | <luka.vidakovic@labsoft.dev> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 9 | Mihailo Dikanovic | E2 54/2025 | <mihailo.dikanovic@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 10 | Nikola Boskovic | E2 57/2025 | <nikola.boskovic.2003@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 11 | [Stefan Mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | E2 128/2025 | <stefan.mitic@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 12 | [Vuk Antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | E2 76/2025 | <vuk.antovic48@gmail.com> | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+
+Legend: 🟢 Merged | ✅ Approved | 🟡 Open | 🔴 Changes Requested | ⬜ Not started

--- a/modules/module-1-git/ASSIGNMENTS.md
+++ b/modules/module-1-git/ASSIGNMENTS.md
@@ -1,11 +1,18 @@
 # Module 1: Git — Assignments
 
-| Student | Repository | PR | Status | Reviewers |
-|---------|-----------|-----|--------|-----------|
-| Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | [#4](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pull/4) | 🟡 Open | @momokrunic |
-| Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) | 🟡 Open | @momokrunic |
-| Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | [#7](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pull/7) | 🟡 Open | — |
-| Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) | 🟡 Open | — |
-| Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | [#12](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/12) | 🟡 Open | @momokrunic |
+| # | Student | Repository | PR | Status | Reviewers |
+|---|---------|-----------|-----|--------|-----------|
+| 1 | Aleksandar Antonic | [sdp-powered-by-ai-agents-name-surname](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | — | ⬜ Not started | — |
+| 2 | Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | [#4](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pull/4) | ✅ Approved | @momokrunic |
+| 3 | Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | [#12](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/12) | 🔴 Changes Requested | @momokrunic |
+| 4 | Ante Resetar | — | — | ⬜ Not started | — |
+| 5 | Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | [#7](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pull/7) | 🔴 Changes Requested | @momokrunic |
+| 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) | ✅ Approved | @momokrunic |
+| 7 | Luka Misojcic | — | — | ⬜ Not started | — |
+| 8 | Luka Vidakovic | — | — | ⬜ Not started | — |
+| 9 | Mihailo Dikanovic | — | — | ⬜ Not started | — |
+| 10 | Nikola Boskovic | — | — | ⬜ Not started | — |
+| 11 | Stefan Mitic | [sdp-powered-by-ai-agents-stefan-mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | — | ⬜ Not started | — |
+| 12 | Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) | 🔴 Changes Requested | @momokrunic |
 
-Legend: 🟢 Merged | 🟡 Open | 🔴 Changes Requested
+Legend: 🟢 Merged | ✅ Approved | 🟡 Open | 🔴 Changes Requested | ⬜ Not started

--- a/modules/module-2-architecture/ASSIGNMENTS.md
+++ b/modules/module-2-architecture/ASSIGNMENTS.md
@@ -1,11 +1,18 @@
 # Module 2: Software Architecture — Assignments
 
-| Student | Repository | PR | Status | Reviewers |
-|---------|-----------|-----|--------|-----------|
-| Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | — | ⬜ Not started | — |
-| Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | — | ⬜ Not started | — |
-| Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | — | ⬜ Not started | — |
-| Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | — | ⬜ Not started | — |
-| Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | — | ⬜ Not started | — |
+| # | Student | Repository | PR | Status | Reviewers |
+|---|---------|-----------|-----|--------|-----------|
+| 1 | Aleksandar Antonic | [sdp-powered-by-ai-agents-name-surname](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | — | ⬜ Not started | — |
+| 2 | Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | — | ⬜ Not started | — |
+| 3 | Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | — | ⬜ Not started | — |
+| 4 | Ante Resetar | — | — | ⬜ Not started | — |
+| 5 | Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | — | ⬜ Not started | — |
+| 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | — | ⬜ Not started | — |
+| 7 | Luka Misojcic | — | — | ⬜ Not started | — |
+| 8 | Luka Vidakovic | — | — | ⬜ Not started | — |
+| 9 | Mihailo Dikanovic | — | — | ⬜ Not started | — |
+| 10 | Nikola Boskovic | — | — | ⬜ Not started | — |
+| 11 | Stefan Mitic | [sdp-powered-by-ai-agents-stefan-mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | — | ⬜ Not started | — |
+| 12 | Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | — | ⬜ Not started | — |
 
-Legend: 🟢 Merged | 🟡 Open | 🔴 Changes Requested | ⬜ Not started
+Legend: 🟢 Merged | ✅ Approved | 🟡 Open | 🔴 Changes Requested | ⬜ Not started

--- a/modules/module-2-architecture/slides/module-2-architecture.md
+++ b/modules/module-2-architecture/slides/module-2-architecture.md
@@ -118,7 +118,7 @@ Each domain has its own language. In AUTH, a User is credentials and tokens. In 
 ---
 
 ## Slide 9: Bounded Contexts
-**Type:** code
+**Type:** image
 **Content:**
 ![Bounded Contexts](../diagrams/bounded-contexts.svg)
 
@@ -205,7 +205,7 @@ This is a fundamental shift. Instead of "call the billing service to create a su
 ---
 
 ## Slide 15: Sync vs Async
-**Type:** code
+**Type:** image
 **Content:**
 ![Sync vs Async](../diagrams/sync-vs-async.svg)
 
@@ -278,7 +278,7 @@ Level 4 is rarely needed. If your code is well-structured, the code itself is th
 ---
 
 ## Slide 20: C4 Level 1 — System Context
-**Type:** code
+**Type:** image
 **Content:**
 ![System Context](../diagrams/system-context.svg)
 
@@ -289,7 +289,7 @@ For the Subscription Platform: a merchant interacts with the platform to create 
 ---
 
 ## Slide 21: C4 Level 2 — Container
-**Type:** code
+**Type:** image
 **Content:**
 ![Container Diagram](../diagrams/container-diagram.svg)
 


### PR DESCRIPTION
## Related Issue
Closes #2

## Changes
- Fixed slide image types (code → image) for 4 PlantUML diagrams in module-2
- Added 7 new students (12 total) to attendance and all assignment tables
- Added leaderboard with gamification scoring system
- Added student directory with index, email, PR tracking per module
- Updated M1 PR statuses after reviews (2 approved, 3 changes requested)
- Updated M2 assignments with full student roster
- Invited 7 students as collaborators

## Testing
- [x] PPTX regenerated with embedded SVG diagrams
- [x] All pre-commit hooks pass
- [x] PR statuses verified via gh CLI