### PR TITLE
#2 [DOCS] Ante M1+M2 reviews, Mihailo M1 merged + M2 approved, leaderboard reorder

### DIFF
--- a/COURSE-TRACKER.md
+++ b/COURSE-TRACKER.md
@@ -7,17 +7,17 @@ Location: 507 НТП | Time: 17:00
 | Rank | Student | 🟢 Merged | ✅ Approved | 🟡 Open | 🔴 Rejected | Score | Streak |
 |------|---------|-----------|------------|---------|-------------|-------|--------|
 | 🥇 | [Ana Zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pulls) ⚡⚡ | 2 | 0 | 0 | 0 | 16 | 🔥 2 |
-| 🥈 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
-| 🥈 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
 | 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 1 | 1 | 0 | 0 | 9 | 🔥 2 |
-| 5 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname/pulls) | 0 | 0 | 0 | 0 | 0 | |
-| 5 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
-| 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
-| 5 | Luka Misojcic | 0 | 0 | 0 | 0 | 0 | |
-| 5 | Luka Vidakovic | 0 | 0 | 0 | 0 | 0 | |
-| 5 | Nikola Boskovic | 0 | 0 | 0 | 0 | 0 | |
-| 5 | [Stefan Mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic/pulls) | 0 | 0 | 0 | 0 | 0 | |
-| 5 | [Vuk Antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
+| 🥉 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
+| 🥉 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
+| 🥉 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
+| 6 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname/pulls) | 0 | 0 | 0 | 0 | 0 | |
+| 6 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
+| 6 | Luka Misojcic | 0 | 0 | 0 | 0 | 0 | |
+| 6 | Luka Vidakovic | 0 | 0 | 0 | 0 | 0 | |
+| 6 | Nikola Boskovic | 0 | 0 | 0 | 0 | 0 | |
+| 6 | [Stefan Mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic/pulls) | 0 | 0 | 0 | 0 | 0 | |
+| 6 | [Vuk Antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
 
 **Scoring:** 🟡 Open = 2 pts | ✅ Approved = 4 pts | 🟢 Merged = 5 pts | 🔴 Changes Requested = 0 pts
 **Streak:** Consecutive modules with a PR submitted 🔥

--- a/COURSE-TRACKER.md
+++ b/COURSE-TRACKER.md
@@ -9,7 +9,7 @@ Location: 507 НТП | Time: 17:00
 | 🥇 | [Ana Zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pulls) ⚡⚡ | 2 | 0 | 0 | 0 | 16 | 🔥 2 |
 | 🥈 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
 | 🥈 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
-| 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 0 | 2 | 0 | 0 | 8 | 🔥 2 |
+| 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 1 | 1 | 0 | 0 | 9 | 🔥 2 |
 | 5 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname/pulls) | 0 | 0 | 0 | 0 | 0 | |
 | 5 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
 | 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
@@ -102,7 +102,7 @@ Project work (schedule TBD)
 | 6 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | E2 51/2025 | <jovanglintic@gmail.com> | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 7 | Luka Misojcic | E2 39/2025 | <luka.misojcic.2019@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 8 | Luka Vidakovic | E2 40/2025 | <luka.vidakovic@labsoft.dev> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| 9 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | E2 54/2025 | <mihailo.dikanovic@rt-rk.com> | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) ✅ | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 9 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | E2 54/2025 | <mihailo.dikanovic@rt-rk.com> | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) 🟢 | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 10 | Nikola Boskovic | E2 57/2025 | <nikola.boskovic.2003@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 11 | [Stefan Mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | E2 128/2025 | <stefan.mitic@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 12 | [Vuk Antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | E2 76/2025 | <vuk.antovic48@gmail.com> | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/COURSE-TRACKER.md
+++ b/COURSE-TRACKER.md
@@ -11,7 +11,7 @@ Location: 507 НТП | Time: 17:00
 | 🥈 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
 | 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
 | 5 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname/pulls) | 0 | 0 | 0 | 0 | 0 | |
-| 5 | Ante Resetar | 0 | 0 | 0 | 0 | 0 | |
+| 5 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
 | 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
 | 5 | Luka Misojcic | 0 | 0 | 0 | 0 | 0 | |
 | 5 | Luka Vidakovic | 0 | 0 | 0 | 0 | 0 | |
@@ -97,7 +97,7 @@ Project work (schedule TBD)
 | 1 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | E2 69/2025 | <aleksandar.antonic00@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 2 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | E2 2/2025 | <aleksandarcetkovic@gmail.com> | [#4](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pull/4) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 3 | [Ana Zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | E2 71/2025 | <ana.zecus@gmail.com> | [#12](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/12) 🟢 | [#14](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/14) 🟢 | ⬜ | ⬜ | ⬜ | ⬜ |
-| 4 | Ante Resetar | E2 74/2025 | <ante.resetar@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 4 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar) | E2 74/2025 | <ante.resetar@rt-rk.com> | [#7](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pull/7) ✅ | [#8](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pull/8) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ |
 | 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | E2 105/2025 | <petrovic.jana12@gmail.com> | [#7](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pull/7) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 6 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | E2 51/2025 | <jovanglintic@gmail.com> | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 7 | Luka Misojcic | E2 39/2025 | <luka.misojcic.2019@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/COURSE-TRACKER.md
+++ b/COURSE-TRACKER.md
@@ -9,7 +9,7 @@ Location: 507 НТП | Time: 17:00
 | 🥇 | [Ana Zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pulls) ⚡⚡ | 2 | 0 | 0 | 0 | 16 | 🔥 2 |
 | 🥈 | [Aleksandar Cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
 | 🥈 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pulls) | 0 | 1 | 0 | 0 | 4 | 🔥 1 |
-| 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
+| 🥈 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pulls) | 0 | 2 | 0 | 0 | 8 | 🔥 2 |
 | 5 | [Aleksandar Antonic](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname/pulls) | 0 | 0 | 0 | 0 | 0 | |
 | 5 | [Ante Resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pulls) | 0 | 1 | 0 | 1 | 4 | 🔥 2 |
 | 5 | [Jana Petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pulls) | 0 | 0 | 0 | 1 | 0 | |
@@ -102,7 +102,7 @@ Project work (schedule TBD)
 | 6 | [Jovan Glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | E2 51/2025 | <jovanglintic@gmail.com> | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) ✅ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 7 | Luka Misojcic | E2 39/2025 | <luka.misojcic.2019@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 8 | Luka Vidakovic | E2 40/2025 | <luka.vidakovic@labsoft.dev> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| 9 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | E2 54/2025 | <mihailo.dikanovic@rt-rk.com> | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) ✅ | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ |
+| 9 | [Mihailo Dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | E2 54/2025 | <mihailo.dikanovic@rt-rk.com> | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) ✅ | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 10 | Nikola Boskovic | E2 57/2025 | <nikola.boskovic.2003@gmail.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 11 | [Stefan Mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | E2 128/2025 | <stefan.mitic@rt-rk.com> | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | 12 | [Vuk Antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | E2 76/2025 | <vuk.antovic48@gmail.com> | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) 🔴 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/modules/module-1-git/ASSIGNMENTS.md
+++ b/modules/module-1-git/ASSIGNMENTS.md
@@ -5,7 +5,7 @@
 | 1 | Aleksandar Antonic | [sdp-powered-by-ai-agents-name-surname](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | — | ⬜ Not started | — |
 | 2 | Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | [#4](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic/pull/4) | ✅ Approved | @momokrunic |
 | 3 | Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | [#12](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/12) | 🟢 Merged | @momokrunic |
-| 4 | Ante Resetar | — | — | ⬜ Not started | — |
+| 4 | Ante Resetar | [sdp-powered-by-ai-agents-ante-resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar) | [#7](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pull/7) | ✅ Approved | @momokrunic |
 | 5 | Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | [#7](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic/pull/7) | 🔴 Changes Requested | @momokrunic |
 | 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) | ✅ Approved | @momokrunic |
 | 7 | Luka Misojcic | — | — | ⬜ Not started | — |

--- a/modules/module-1-git/ASSIGNMENTS.md
+++ b/modules/module-1-git/ASSIGNMENTS.md
@@ -10,7 +10,7 @@
 | 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | [#9](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic/pull/9) | ✅ Approved | @momokrunic |
 | 7 | Luka Misojcic | — | — | ⬜ Not started | — |
 | 8 | Luka Vidakovic | — | — | ⬜ Not started | — |
-| 9 | Mihailo Dikanovic | [sdp-powered-by-ai-agents-mihailo-dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) | ✅ Approved | @momokrunic |
+| 9 | Mihailo Dikanovic | [sdp-powered-by-ai-agents-mihailo-dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | [#10](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/10) | 🟢 Merged | @momokrunic |
 | 10 | Nikola Boskovic | — | — | ⬜ Not started | — |
 | 11 | Stefan Mitic | [sdp-powered-by-ai-agents-stefan-mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | — | ⬜ Not started | — |
 | 12 | Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | [#8](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic/pull/8) | 🔴 Changes Requested | @momokrunic |

--- a/modules/module-2-architecture/ASSIGNMENTS.md
+++ b/modules/module-2-architecture/ASSIGNMENTS.md
@@ -10,7 +10,7 @@
 | 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | — | ⬜ Not started | — |
 | 7 | Luka Misojcic | — | — | ⬜ Not started | — |
 | 8 | Luka Vidakovic | — | — | ⬜ Not started | — |
-| 9 | Mihailo Dikanovic | [sdp-powered-by-ai-agents-mihailo-dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) | 🔴 Changes Requested | @momokrunic |
+| 9 | Mihailo Dikanovic | [sdp-powered-by-ai-agents-mihailo-dikanovic](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic) | [#12](https://github.com/dikanovicmihailo/sdp-powered-by-ai-agents-mihailo-dikanovic/pull/12) | ✅ Approved | @momokrunic |
 | 10 | Nikola Boskovic | — | — | ⬜ Not started | — |
 | 11 | Stefan Mitic | [sdp-powered-by-ai-agents-stefan-mitic](https://github.com/notstefan1/sdp-powered-by-ai-agents-stefan-mitic) | — | ⬜ Not started | — |
 | 12 | Vuk Antovic | [sdp-powered-by-ai-agents-vuk-antovic](https://github.com/antovic/sdp-powered-by-ai-agents-vuk-antovic) | — | ⬜ Not started | — |

--- a/modules/module-2-architecture/ASSIGNMENTS.md
+++ b/modules/module-2-architecture/ASSIGNMENTS.md
@@ -5,7 +5,7 @@
 | 1 | Aleksandar Antonic | [sdp-powered-by-ai-agents-name-surname](https://github.com/antonic00/sdp-powered-by-ai-agents-name-surname) | — | ⬜ Not started | — |
 | 2 | Aleksandar Cetkovic | [sdp-powered-by-ai-agents-aleksandar-cetkovic](https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic) | — | ⬜ Not started | — |
 | 3 | Ana Zec | [sdp-powered-by-ai-agents-ana-zec](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec) | [#14](https://github.com/AnaZec/sdp-powered-by-ai-agents-ana-zec/pull/14) | 🟢 Merged | @momokrunic |
-| 4 | Ante Resetar | — | — | ⬜ Not started | — |
+| 4 | Ante Resetar | [sdp-powered-by-ai-agents-ante-resetar](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar) | [#8](https://github.com/antres1/sdp-powered-by-ai-agents-ante-resetar/pull/8) | 🔴 Changes Requested | @momokrunic |
 | 5 | Jana Petrovic | [sdp-powered-by-ai-agents-jana-petrovic](https://github.com/ktzjana/sdp-powered-by-ai-agents-jana-petrovic) | — | ⬜ Not started | — |
 | 6 | Jovan Glintic | [sdp-powered-by-ai-agents-jovan-glintic](https://github.com/jglintic/sdp-powered-by-ai-agents-jovan-glintic) | — | ⬜ Not started | — |
 | 7 | Luka Misojcic | — | — | ⬜ Not started | — |


### PR DESCRIPTION
## Related Issue
Closes #2

## Changes
- Reviewed Ante Resetar M1 (#7) — ✅ approved, M2 (#8) — 🔴 SVG references needed
- Approved Mihailo M2 (#12) after SVG + sequence diagram fixes
- Mihailo merged M1 — now 9 pts, sole 🥈
- Leaderboard reordered by score (🥇 Ana 16, 🥈 Mihailo 9, 🥉 Cetkovic/Ante/Jovan 4)
- Invited Ante as collaborator

## Testing
- [x] Pre-commit hooks pass