### PR TITLE
#43 docs(sphinx): add course documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ a Kiro CLI agent.
 See the [Intro slides](modules/intro/) for a deeper dive into these
 concepts.
 
+📚 **[Course Documentation](https://labsoft-ai.github.io/SDP-Powered-by-AI-Agents-2026-04-06/)**
+
 ## Course Structure
 
 The course has two parts:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 # pylint: disable=invalid-name,redefined-builtin
 
 project = "SDP Powered by AI Agents"
-copyright = "2026, Momcilo Krunic (LabSoft AI). Licensed under CC BY 4.0"  # noqa: A001
+copyright = '2026, <a href="mailto:momo@labsoft.ai">Momcilo Krunic</a> (<a href="https://labsoft.ai">LabSoft AI</a>). Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>'  # noqa: A001
 author = "Momcilo Krunic (LabSoft AI)"
 
 extensions = [


### PR DESCRIPTION
## Summary
- Sphinx docs with sphinx-wagtail-theme, forced dark hacker terminal theme
- GitHub Actions workflow to build and deploy to GitHub Pages
- Copyright/license aligned with LICENSE (CC BY 4.0)
- SVG diagrams render correctly via relative-images includes
- Hardcoded GitHub repo link in header
- Documentation link added to README

## Tested
- Local sphinx-build succeeds with no errors
- Dark theme renders correctly regardless of OS preference

Closes #43